### PR TITLE
support x86_64 for eventfd syscall

### DIFF
--- a/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
+++ b/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
@@ -15,7 +15,7 @@ numeric_enum_macro::numeric_enum! {
 pub enum FsSyscallId {
     // fs
     GETCWD = 17,
-    EVENT_FD = 19,
+    EVENTFD = 19,
     EPOLL_CREATE = 20,
     EPOLL_CTL = 21,
     EPOLL_WAIT = 22,
@@ -69,7 +69,8 @@ numeric_enum_macro::numeric_enum! {
         // fs
         OPEN = 2,
         STAT = 4,
-        EVENT_FD = 284,
+        EVENTFD = 284,
+        EVENTFD2 = 290,
         GETCWD = 79,
         UNLINK = 87,
         EPOLL_CREATE = 213,

--- a/ulib/axstarry/src/syscall_fs/imp/eventfd.rs
+++ b/ulib/axstarry/src/syscall_fs/imp/eventfd.rs
@@ -5,9 +5,6 @@ use crate::syscall_fs::ctype::eventfd::EventFd;
 use crate::{SyscallError, SyscallResult};
 
 pub fn syscall_eventfd(args: [usize; 6]) -> SyscallResult {
-    #[cfg(target_arch = "x86_64")]
-    unimplemented!("syscall eventfd is not tested in x86_64 yet");
-
     let initval = args[0] as u64;
     let flags = args[1] as u32;
 

--- a/ulib/axstarry/src/syscall_fs/mod.rs
+++ b/ulib/axstarry/src/syscall_fs/mod.rs
@@ -13,7 +13,7 @@ use imp::*;
 /// 文件系统相关系统调用
 pub fn fs_syscall(syscall_id: fs_syscall_id::FsSyscallId, args: [usize; 6]) -> SyscallResult {
     match syscall_id {
-        EVENT_FD => syscall_eventfd(args),
+        EVENTFD => syscall_eventfd(args),
         OPENAT => syscall_openat(args),
         CLOSE => syscall_close(args),
         READ => syscall_read(args),
@@ -59,6 +59,11 @@ pub fn fs_syscall(syscall_id: fs_syscall_id::FsSyscallId, args: [usize; 6]) -> S
         PPOLL => syscall_ppoll(args),
         PSELECT6 => syscall_pselect6(args),
 
+        #[cfg(target_arch = "x86_64")]
+        // eventfd syscall in x86_64 does not support flags, use 0 instead
+        EVENTFD => syscall_eventfd([args[0], 0, 0, 0, 0, 0]),
+        #[cfg(target_arch = "x86_64")]
+        EVENTFD2 => syscall_eventfd(args),
         #[cfg(target_arch = "x86_64")]
         DUP2 => syscall_dup2(args),
         #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Test cases: https://github.com/binary-bruce/starry_fastdds_testcases/pull/2/files (build test case image for x86_64)
How to test: put the `eventfd-testcases-x86_64` inside testcases/testsuites-x86_64-linux-musl
Test result:
<img width="564" alt="image" src="https://github.com/Arceos-monolithic/Starry/assets/127000969/da17dac4-9457-4820-b079-9422e340da73">
