### PR TITLE
bug: fix the bug of the memory_set creation, in the aarch64 arch

### DIFF
--- a/modules/axmem/src/lib.rs
+++ b/modules/axmem/src/lib.rs
@@ -61,8 +61,17 @@ impl MemorySet {
         }
     }
 
+    /// Create a new MemorySet
+    pub fn new_memory_set() -> Self {
+        if cfg!(target_arch = "aarch64") {
+            Self::new_empty()
+        } else {
+            Self::new_with_kernel_mapped()
+        }
+    }
+
     /// Create a new MemorySet with kernel mapped regions.
-    pub fn new_with_kernel_mapped() -> Self {
+    fn new_with_kernel_mapped() -> Self {
         let mut page_table = PageTable::try_new().expect("Error allocating page table.");
 
         for r in memory_regions() {

--- a/modules/axprocess/src/process.rs
+++ b/modules/axprocess/src/process.rs
@@ -197,7 +197,7 @@ impl Process {
     /// 根据给定参数创建一个新的进程，作为应用程序初始进程
     pub fn init(args: Vec<String>, envs: &Vec<String>) -> AxResult<AxTaskRef> {
         let path = args[0].clone();
-        let mut memory_set = MemorySet::new_with_kernel_mapped();
+        let mut memory_set = MemorySet::new_memory_set();
         #[cfg(feature = "signal")]
         {
             use axhal::mem::virt_to_phys;


### PR DESCRIPTION
riscv64内核地址和用户地址共用一个memory_set, 但是在aarch64下面是分开的, 这就导致了mmap可能会出现找到free area但是却被分配的情况. 目前是在axmem下实现的