### PR TITLE
implement syscall mremap

### DIFF
--- a/modules/axmem/src/lib.rs
+++ b/modules/axmem/src/lib.rs
@@ -19,7 +19,7 @@ extern crate log;
 use axhal::{
     arch::flush_tlb,
     mem::{memory_regions, phys_to_virt, PhysAddr, VirtAddr, PAGE_SIZE_4K},
-    paging::{MappingFlags, PageSize, PageTable},
+    paging::{MappingFlags, PageSize, PageTable, PagingError},
 };
 
 // TODO: a real allocator
@@ -503,6 +503,76 @@ impl MemorySet {
     pub fn detach_shared_mem(&mut self, _shmid: i32) {
         todo!()
     }
+
+    /// mremap: change the size of a mapping, potentially moving it at the same time.
+    pub fn mremap(&mut self, old_start: VirtAddr, old_size: usize, new_size: usize) -> isize {
+        info!(
+            "[mremap] old_start: {:?}, old_size: {:?}), new_size: {:?}",
+            old_start,
+            old_size,
+            new_size
+        );
+
+        // Todo: check flags
+        let start = self.find_free_area(old_start, new_size); 
+        if start.is_none() {
+            return -1;
+        }
+
+        let old_page_start_addr = old_start.align_down_4k();
+        let old_page_end_addr = old_start + old_size - 1;
+        let old_page_end = old_page_end_addr.align_down_4k().into();
+        let old_page_start: usize = old_page_start_addr.into();
+          
+        let addr: isize = match start {
+            Some(start) => {
+                info!("found area [{:?}, {:?})", start, start + new_size);
+
+                self.new_region(
+                    start,
+                    new_size,
+                    MappingFlags::USER | MappingFlags::READ | MappingFlags::WRITE,
+                    None,
+                    None);
+                flush_tlb(None);
+
+                let end = start + new_size;
+                assert!(end.is_aligned_4k());
+
+                for addr in (old_page_start..=old_page_end).step_by(PAGE_SIZE_4K) {
+                    let vaddr = VirtAddr::from(addr);
+                    match check_page_table_entry_validity(vaddr, &self.page_table) {
+                        Ok(_) => {
+                            // 如果旧地址已经分配内存，进行页copy；否则不做处理
+                            let page_start = start + addr - old_page_start;
+                            // let page_end = page_start + PAGE_SIZE_4K - 1;
+                            if self.manual_alloc_for_lazy(page_start).is_ok() {
+                                let old_data = unsafe {
+                                    core::slice::from_raw_parts(vaddr.as_ptr(), PAGE_SIZE_4K)
+                                };
+                                let new_data = unsafe {
+                                    core::slice::from_raw_parts_mut(page_start.as_mut_ptr(), PAGE_SIZE_4K)
+                                };
+                                new_data[..PAGE_SIZE_4K].copy_from_slice(old_data);
+                            }
+                        }
+                        Err(PagingError::NotMapped) => {
+                            error!("NotMapped addr: {:x}", vaddr);
+                            continue
+                        }
+                        _ => return -1,
+                    };
+                }
+                self.munmap(old_start, old_size);
+                flush_tlb(None);
+                start.as_usize() as isize
+            }
+            None => -1,
+        };
+
+        debug!("[mremap] return addr: 0x{:x}", addr);
+        addr
+    }
 }
 
 impl MemorySet {
@@ -519,20 +589,19 @@ impl MemorySet {
             .iter_mut()
             .find(|(_, area)| area.vaddr <= addr && addr < area.end_va())
         {
-            let entry = self.page_table.get_entry_mut(addr);
-            if entry.is_err() {
-                // 地址不合法
-                return Err(AxError::InvalidInput);
-            }
+            match check_page_table_entry_validity(addr, &self.page_table) {
+                Err(PagingError::NoMemory) => Err(AxError::InvalidInput),
+                Err(PagingError::NotMapped) => {
+                    // 若未分配物理页面，则手动为其分配一个页面，写入到对应页表中
+                    let entry = self.page_table.get_entry_mut(addr).unwrap().0;
 
-            let entry = entry.unwrap().0;
-            if !entry.is_present() {
-                // 若未分配物理页面，则手动为其分配一个页面，写入到对应页表中
-                if !area.handle_page_fault(addr, entry.flags(), &mut self.page_table) {
-                    return Err(AxError::BadAddress);
-                }
+                    if !area.handle_page_fault(addr, entry.flags(), &mut self.page_table) {
+                        return Err(AxError::BadAddress);
+                    }
+                    Ok(())
+                },
+                _ => Ok(())
             }
-            Ok(())
         } else {
             Err(AxError::InvalidInput)
         }
@@ -611,4 +680,21 @@ impl Drop for MemorySet {
     fn drop(&mut self) {
         self.unmap_user_areas();
     }
+}
+
+/// 验证地址是否已分配页面
+pub fn check_page_table_entry_validity(addr: VirtAddr, page_table: &PageTable) -> Result<(), PagingError> {
+    let entry = page_table.get_entry_mut(addr);
+    
+    if entry.is_err() {
+        // 地址不合法
+        return Err(PagingError::NoMemory);
+    }
+
+    let entry = entry.unwrap().0;
+    if !entry.is_present() {
+        return Err(PagingError::NotMapped);
+    }
+
+    Ok(())
 }

--- a/ulib/axstarry/src/ctypes.rs
+++ b/ulib/axstarry/src/ctypes.rs
@@ -169,6 +169,20 @@ bitflags! {
     }
 }
 
+bitflags! {
+    #[derive(Debug)]
+    /// 指定 mremap 的选项
+    pub struct MREMAPFlags: u32 {
+        /// 允许将映射重新定位到新地址
+        const MREMAP_MAYMOVE = 1 << 0;
+        /// 指定映射必须移动到的页面对齐地址，必须和MREMAP_MAYMOVE一起使用
+        const MREMAP_FIXED = 1 << 1;
+
+        /// 将映射重新映射到新地址，但不会取消旧地址的映射，必须和MREMAP_MAYMOVE一起使用
+        const MREMAP_DONTUNMAP = 1 << 2;
+    }
+}
+
 /// sys_uname 中指定的结构体类型
 #[repr(C)]
 pub struct UtsName {

--- a/ulib/axstarry/src/syscall_mem/mem_syscall_id.rs
+++ b/ulib/axstarry/src/syscall_mem/mem_syscall_id.rs
@@ -18,6 +18,7 @@ pub enum MemSyscallId {
     SHMAT = 196,
     BRK = 214,
     MUNMAP = 215,
+    MREMAP = 216,
     MMAP = 222,
     MSYNC = 227,
     MPROTECT = 226,

--- a/ulib/axstarry/src/syscall_mem/mod.rs
+++ b/ulib/axstarry/src/syscall_mem/mod.rs
@@ -13,6 +13,7 @@ pub fn mem_syscall(syscall_id: mem_syscall_id::MemSyscallId, args: [usize; 6]) -
     match syscall_id {
         BRK => syscall_brk(args),
         MUNMAP => syscall_munmap(args),
+        MREMAP => syscall_mremap(args),
         #[cfg(feature = "fs")]
         MMAP => syscall_mmap(args),
         MSYNC => syscall_msync(args),


### PR DESCRIPTION
`mremap` 是 Linux 系统调用，它的作用主要是重新映射一段内存区域。当一个进程使用 `mmap` 系统调用映射了一段内存后，如果希望调整这段内存的大小，可以使用 `mremap` 来实现。`mremap` 可以扩大或者减小已映射内存区域的大小，并且可能会移动内存区域到新的地址。

/// # Arguments
/// * `old_addr` - usize
/// * `old_size` - usize
/// * `new_size` - usize
/// * `flags` - usize
/// * `new_addr` - usize

其中参数含义如下：

- `old_addr`：原始映射区域的起始地址。
- `old_size`：原始映射区域的大小。
- `new_size`：期望的映射区域的新大小。
- `flags`：控制 `mremap` 行为的标志位，包括 `MREMAP_MAYMOVE`（允许内核移动映射区域到新的地址）和 `MREMAP_FIXED`（将映射区域移动到给定地址，需要和 `MREMAP_MAYMOVE` 一起使用）。
- `new_addr`（可选参数）：当使用 `MREMAP_FIXED` 标志时，指定新的映射区域的地址。

`mremap` 可用于实现动态内存管理，比如增长或减少一个动态数组的大小。它可以减少因映射区域大小改变而带来的额外拷贝开销，因为它允许在内存扩大时保留原有内容。

如果 `mremap` 成功，它会返回新内存区域的地址；如果失败，它会返回 `MAP_FAILED`（(void *)-1）并设置 `errno` 来表示错误原因。