### PR TITLE
remove duplicate variables in EpollEvent

### DIFF
--- a/ulib/axstarry/src/syscall_fs/ctype/epoll.rs
+++ b/ulib/axstarry/src/syscall_fs/ctype/epoll.rs
@@ -44,9 +44,6 @@ pub struct EpollEvent {
     pub event_type: EpollEventType,
     /// 事件中使用到的数据，如fd等
     pub data: u64,
-    pub fd: i32,
-    pub data_u32: u32,
-    pub data_u64: u64,
 }
 
 numeric_enum_macro::numeric_enum! {
@@ -195,9 +192,6 @@ impl EpollFile {
                     ret_events.push(EpollEvent {
                         event_type: EpollEventType::EPOLLERR,
                         data: req_event.data,
-                        fd: -1,
-                        data_u32: 0,
-                        data_u64: 0,
                     });
                 }
             }

--- a/ulib/axstarry/src/syscall_fs/ctype/eventfd.rs
+++ b/ulib/axstarry/src/syscall_fs/ctype/eventfd.rs
@@ -169,6 +169,7 @@ mod tests {
 
     #[test]
     fn test_read_with_bad_input() {
+        use axerrno::AxError;
         let event_fd = EventFd::new(42, 0);
         let event_fd_val = 0u32;
         let result = event_fd.read(&mut event_fd_val.to_ne_bytes());
@@ -179,7 +180,7 @@ mod tests {
     fn test_write() {
         let event_fd = EventFd::new(42, 0);
         let val = 12u64;
-        event_fd.write(&val.to_ne_bytes()[0..core::mem::size_of::<u64>()]);
+        let _ = event_fd.write(&val.to_ne_bytes()[0..core::mem::size_of::<u64>()]);
 
         let event_fd_val = 0u64;
         event_fd.read(&mut event_fd_val.to_ne_bytes()).unwrap();


### PR DESCRIPTION
在整合redis相关commit时, 未对EpollEvent部分进行细看, 发现data部分其实就是union的fd, data_u32, data_u64, 非常抱歉. 

修复eventfd的测试部分的error提示, 同时想问一下这部分单元测试是否还需要保留