### PR TITLE
syscall: fix ioctl return 0 but isatty() needs non zero

### DIFF
--- a/modules/axfs/src/api/port.rs
+++ b/modules/axfs/src/api/port.rs
@@ -343,7 +343,7 @@ pub trait FileIO: AsAny + Send + Sync {
     }
 
     /// To control the file descriptor
-    fn ioctl(&self, _request: usize, _arg1: usize) -> AxResult<()> {
+    fn ioctl(&self, _request: usize, _arg1: usize) -> AxResult<isize> {
         Err(AxError::Unsupported)
     }
 }
@@ -405,6 +405,10 @@ pub const TIOCGPGRP: usize = 0x540F;
 pub const TIOCSPGRP: usize = 0x5410;
 #[allow(missing_docs)]
 pub const TIOCGWINSZ: usize = 0x5413;
+#[allow(missing_docs)]
+pub const FIONBIO: usize = 0x5421;
+#[allow(missing_docs)]
+pub const FIOCLEX: usize = 0x5451;
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
 /// the size of the console window

--- a/modules/axprocess/src/stdio.rs
+++ b/modules/axprocess/src/stdio.rs
@@ -1,7 +1,7 @@
 use axerrno::{AxError, AxResult};
 use axfs::api::port::{
-    ConsoleWinSize, FileExt, FileIO, FileIOType, OpenFlags, TCGETS, TIOCGPGRP, TIOCGWINSZ,
-    TIOCSPGRP, FIONBIO, FIOCLEX,
+    ConsoleWinSize, FileExt, FileIO, FileIOType, OpenFlags, FIOCLEX, FIONBIO, TCGETS, TIOCGPGRP,
+    TIOCGWINSZ, TIOCSPGRP,
 };
 use axhal::console::{getchar, write_bytes};
 use axio::{Read, Seek, SeekFrom, Write};
@@ -132,7 +132,7 @@ impl FileIO for Stdin {
                 }
                 Ok(0)
             }
-            FIOCLEX => Ok(0),            
+            FIOCLEX => Ok(0),
             _ => Err(AxError::Unsupported),
         }
     }
@@ -376,5 +376,5 @@ impl FileIO for Stderr {
             FIOCLEX => Ok(0),
             _ => Err(AxError::Unsupported),
         }
-    }    
+    }
 }

--- a/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
+++ b/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
@@ -24,6 +24,7 @@ pub enum FsSyscallId {
     FCNTL64 = 25,
     IOCTL = 29,
     MKDIRAT = 34,
+    SYMLINKAT = 36,    
     UNLINKAT = 35,
     LINKAT = 37,
     RENAMEAT = 38,

--- a/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
+++ b/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
@@ -83,6 +83,7 @@ numeric_enum_macro::numeric_enum! {
         FCNTL64 = 72,
         IOCTL = 16,
         MKDIRAT = 258,
+        SYMLINKAT = 266,
         RENAME = 82,
         MKDIR = 83,
         RMDIR = 84,

--- a/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
+++ b/ulib/axstarry/src/syscall_fs/fs_syscall_id.rs
@@ -24,7 +24,7 @@ pub enum FsSyscallId {
     FCNTL64 = 25,
     IOCTL = 29,
     MKDIRAT = 34,
-    SYMLINKAT = 36,    
+    SYMLINKAT = 36,
     UNLINKAT = 35,
     LINKAT = 37,
     RENAMEAT = 38,

--- a/ulib/axstarry/src/syscall_fs/imp/ctl.rs
+++ b/ulib/axstarry/src/syscall_fs/imp/ctl.rs
@@ -449,8 +449,10 @@ pub fn syscall_ioctl(args: [usize; 6]) -> SyscallResult {
     }
 
     let file = fd_table[fd].clone().unwrap();
-    let _ = file.ioctl(request, argp);
-    Ok(0)
+    match file.ioctl(request, argp) {
+        Ok(ret) => Ok(ret),
+        Err(_) => Ok(0),
+    }
 }
 
 /// 53

--- a/ulib/axstarry/src/syscall_fs/mod.rs
+++ b/ulib/axstarry/src/syscall_fs/mod.rs
@@ -51,6 +51,7 @@ pub fn fs_syscall(syscall_id: fs_syscall_id::FsSyscallId, args: [usize; 6]) -> S
         COPYFILERANGE => syscall_copyfilerange(args),
         LINKAT => sys_linkat(args),
         UNLINKAT => syscall_unlinkat(args),
+        SYMLINKAT => Ok(0),
         UTIMENSAT => syscall_utimensat(args),
         EPOLL_CREATE => syscall_epoll_create1(args),
         EPOLL_CTL => syscall_epoll_ctl(args),


### PR DESCRIPTION
在跑python脚本时，python进入交互模式。原因是isatty()调用ioctl，request参数为TIOCGWINSZ，当返回值为0时进入交互模式；非零时进入脚本模式。

主要改动：
修改trait FileIO的ioctl返回类型；
增加filedesc的ioctl实现；
增加stdout, stderr的ioctl实现；
增加syscall SYMLINKAT，直接返回Ok（0）