### PR TITLE
Add MREMAP syscall ID to ulib

### DIFF
--- a/ulib/axstarry/src/syscall_mem/mem_syscall_id.rs
+++ b/ulib/axstarry/src/syscall_mem/mem_syscall_id.rs
@@ -39,6 +39,7 @@ numeric_enum_macro::numeric_enum! {
         SHMAT = 30,
         BRK = 12,
         MUNMAP = 11,
+        MREMAP = 25,
         MMAP = 9,
         MSYNC = 26,
         MPROTECT = 10,


### PR DESCRIPTION
Otherwise it's undeclared and becomes a catch-all pattern in https://github.com/Arceos-monolithic/Starry/blob/main/ulib/axstarry/src/syscall_mem/mod.rs#L16 , causing other memory related syscalls unreachable.